### PR TITLE
Oryx 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Prestrafe tool | Player is using a static turnrate to get 289 walk speed. Same a
 Average strafe too close to 0 | The average strafe offset is suspiciously near 0 | oryx-strafe
 Too many perfect strafes | The average strafe offset is not too close to 0, but there is a suspiciously high frequency of 0s | oryx-strafe
 Movement config | Player exhibits behavior that is humanly possible, but movement configs would enforce it | oryx-configcheck
++klook usage | A movement config that disables +forward and +back in specific cases (such as LJ binds) | oryx-configcheck
 Unsynchronised movement | Wish velocity does not align with with the player's buttons variable | oryx-sanity
 Invalid wish velocity | Wish velocity can only be specific values ([link 1](https://mxr.alliedmods.net/hl2sdk-css/source/game/client/in_main.cpp#557), [link 2](https://mxr.alliedmods.net/hl2sdk-css/source/game/client/in_main.cpp#842)) | oryx-sanity
 Wish velocity is too high | Wish velocity exceeds the default `cl_forwardspeed` or `cl_sidespeed` settings | oryx-sanity

--- a/addons/sourcemod/scripting/include/oryx.inc
+++ b/addons/sourcemod/scripting/include/oryx.inc
@@ -54,14 +54,24 @@ enum
 #define bhoptimer
 
 /**
- * Call to activate oryx's trigger procedure (logging, kicking, admin notifications, etc..).
+ * Called when Oryx gets triggered on a client.
+ *
+ * @param client				Client entity index.
+ * @param level					Level of detection as defined in the above enum.
+ * @param cheat					Short description or name of the cheat being detected. 32 cells char array.
+ * @return						Plugin_Continue to do nothing. Plugin_Changed to modify values. Plugin_Handled to abort kicks. Plugin_Stop to completely ignore the trigger.
+ */
+forward Action Oryx_OnTrigger(int client, int &level, char[] cheat);
+
+/**
+ * Call to activate Oryx's trigger procedure (logging, kicking, admin notifications, etc..).
  *
  * @param client				Client entity index.
  * @param level					Level of detection as defined in the above enum.
  * @param cheat					Short description or name of the cheat being detected.
- * @noreturn
+ * @return						Return value of the Oryx_OnTrigger forward.
  */
-native void Oryx_Trigger(int client, int level, char[] cheat);
+native Action Oryx_Trigger(int client, int level, const char[] cheat);
 
 /**
  * Prints a message to admins' chat.

--- a/addons/sourcemod/scripting/include/oryx.inc
+++ b/addons/sourcemod/scripting/include/oryx.inc
@@ -90,14 +90,14 @@ native void Oryx_PrintToAdmins(char[] msg);
 native void Oryx_PrintToAdminsConsole(char[] msg);
 
 /**
- * Tests if f1 is within a 1/frac threshold of f2.
+ * Checks if f1 is inbetween a specified threshold of f12.
  *
  * @param f1					First value.
  * @param f2					Second value.
- * @param frac					Used as a fractional threshold of f2 for f1 to be within.
+ * @param frac					Used as a threshold of f2 for f1 to be within.
  * @return 						True if the test passed.
  */
-native bool Oryx_WithinFlThresh(float f1, float f2, float frac);
+native bool Oryx_WithinThreshold(float f1, float f2, float threshold);
 
 /**
  * A tiny function to veify if the player fits gameplay.

--- a/addons/sourcemod/scripting/include/oryx.inc
+++ b/addons/sourcemod/scripting/include/oryx.inc
@@ -21,7 +21,7 @@
 #endif
 #define _oryx_included
 
-#define ORYX_VERSION "1.1"
+#define ORYX_VERSION "1.2"
 
 /**
 * List of current detection descriptions:

--- a/addons/sourcemod/scripting/oryx-configcheck.sp
+++ b/addons/sourcemod/scripting/oryx-configcheck.sp
@@ -134,6 +134,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	return SetupMove(client, buttons, vel);
 }
 
+#if defined bhoptimer
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style)
 {
 	// Ignore whitelisted styles.
@@ -147,6 +148,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 	return SetupMove(client, buttons, vel);
 }
+#endif
 
 Action SetupMove(int client, int &buttons, float vel[3])
 {

--- a/addons/sourcemod/scripting/oryx-sanity.sp
+++ b/addons/sourcemod/scripting/oryx-sanity.sp
@@ -201,15 +201,15 @@ Action SetupMove(int client, int buttons, int mousedx, float yaw, float vel[3])
 	}
 
 	bool bBadInput = false;
+	bool bUnsure = false;
+
 	int iLR = (buttons & (IN_LEFT | IN_RIGHT));
+	float fDeltaAngle = yaw - gF_PreviousAngle[client];
 
 	// Only pass if mouse movement isn't being tampered by +left/right.
 	// TODO: Don't allow cl_yawspeed 0?
 	if(IsLegalMoveType(client) && mousedx != 0 && (iLR == (IN_LEFT | IN_RIGHT) || iLR == 0))
 	{
-		bool bUnsure = false;
-		float fDeltaAngle = yaw - gF_PreviousAngle[client];
-
 		if(fDeltaAngle > 180.0)
 		{
 			fDeltaAngle -= 360.0;
@@ -240,7 +240,7 @@ Action SetupMove(int client, int buttons, int mousedx, float yaw, float vel[3])
 			bBadInput = true;
 		}
 
-		else if(bUnsure)
+		if(bUnsure)
 		{
 			bBadInput = false;
 		}
@@ -252,7 +252,10 @@ Action SetupMove(int client, int buttons, int mousedx, float yaw, float vel[3])
 	{
 		if(++gI_BadInputStreak[client] >= SAMPLE_SIZE)
 		{
-			Oryx_Trigger(client, TRIGGER_HIGH_NOKICK, DESC4);
+			char[] sReason = new char[32];
+			FormatEx(sReason, 32, DESC4 ... "d%.03f x%d u%d", fDeltaAngle, mousedx, bUnsure);
+
+			Oryx_Trigger(client, TRIGGER_MEDIUM, sReason);
 
 			gI_BadInputStreak[client] = 0;
 		}

--- a/addons/sourcemod/scripting/oryx-sanity.sp
+++ b/addons/sourcemod/scripting/oryx-sanity.sp
@@ -75,6 +75,14 @@ public void OnPluginStart()
 	{
 		OnLibraryAdded("dhooks");
 	}
+
+	for(int i = 1; i <= MaxClients; i++)
+	{
+		if(IsClientInGame(i))
+		{
+			OnClientPutInServer(i);
+		}
+	}
 }
 
 public MRESReturn DHook_Teleport(int pThis, Handle hReturn)
@@ -123,14 +131,6 @@ public void OnLibraryAdded(const char[] name)
 				if(gEV_Type == Engine_CSGO)
 				{
 					DHookAddParam(gH_Teleport, HookParamType_Bool);
-				}
-
-				for(int i = 1; i <= MaxClients; i++)
-				{
-					if(IsClientInGame(i))
-					{
-						OnClientPutInServer(i);
-					}
 				}
 			}
 

--- a/addons/sourcemod/scripting/oryx-sanity.sp
+++ b/addons/sourcemod/scripting/oryx-sanity.sp
@@ -45,6 +45,8 @@ int gI_BadInputStreak[MAXPLAYERS+1];
 bool gB_Shavit = false;
 Handle gH_Teleport = null;
 
+bool gB_TriggeredRawInput[MAXPLAYERS+1];
+
 public Plugin myinfo = 
 {
 	name = "ORYX sanity module",
@@ -98,6 +100,7 @@ public MRESReturn DHook_Teleport(int pThis, Handle hReturn)
 public void OnClientPutInServer(int client)
 {
 	gI_BadInputStreak[client] = 0;
+	gB_TriggeredRawInput[client] = false;
 
 	if(gH_Teleport != null)
 	{
@@ -208,7 +211,7 @@ Action SetupMove(int client, int buttons, int mousedx, float yaw, float vel[3])
 
 	// Only pass if mouse movement isn't being tampered by +left/right.
 	// TODO: Don't allow cl_yawspeed 0?
-	if(IsLegalMoveType(client) && mousedx != 0 && (iLR == (IN_LEFT | IN_RIGHT) || iLR == 0))
+	if(!gB_TriggeredRawInput[client] && IsLegalMoveType(client) && mousedx != 0 && (iLR == (IN_LEFT | IN_RIGHT) || iLR == 0))
 	{
 		if(fDeltaAngle > 180.0)
 		{
@@ -258,6 +261,7 @@ Action SetupMove(int client, int buttons, int mousedx, float yaw, float vel[3])
 			Oryx_Trigger(client, TRIGGER_MEDIUM, sReason);
 
 			gI_BadInputStreak[client] = 0;
+			gB_TriggeredRawInput[client] = true;
 		}
 	}
 

--- a/addons/sourcemod/scripting/oryx-sanity.sp
+++ b/addons/sourcemod/scripting/oryx-sanity.sp
@@ -175,6 +175,12 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style, any stylesettings[STYLESETTINGS_SIZE], int mouse[2])
 {
+	// Don't do sanity checks on players that aren't running, to reduce false positive risks.
+	if(status != Timer_Running)
+	{
+		return Plugin_Continue;
+	}
+
 	// Ignore whitelisted styles.
 	char[] sSpecial = new char[32];
 	Shavit_GetStyleStrings(style, sSpecialString, sSpecial, 32);

--- a/addons/sourcemod/scripting/oryx-sanity.sp
+++ b/addons/sourcemod/scripting/oryx-sanity.sp
@@ -34,7 +34,7 @@
 #define DESC4 "Raw input discrepancy"
 
 // Amount of ticks in a row where raw input can have discrepancies before acting.
-#define SAMPLE_SIZE 20
+#define SAMPLE_SIZE 60
 
 EngineVersion gEV_Type = Engine_Unknown;
 

--- a/addons/sourcemod/scripting/oryx-sanity.sp
+++ b/addons/sourcemod/scripting/oryx-sanity.sp
@@ -176,6 +176,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	return SetupMove(client, buttons, mouse[0], angles[1], vel);
 }
 
+#if defined bhoptimer
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style, any stylesettings[STYLESETTINGS_SIZE], int mouse[2])
 {
 	// Don't do sanity checks on players that aren't running, to reduce false positive risks.
@@ -195,6 +196,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 	return SetupMove(client, buttons, mouse[0], angles[1], vel);
 }
+#endif
 
 Action SetupMove(int client, int buttons, int mousedx, float yaw, float vel[3])
 {

--- a/addons/sourcemod/scripting/oryx-scroll.sp
+++ b/addons/sourcemod/scripting/oryx-scroll.sp
@@ -226,17 +226,17 @@ public Action Command_PrintScrollStats(int client, int args)
 		return Plugin_Handled;
 	}
 
-	char[] sScrollStats = new char[256];
-	GetScrollStatsFormatted(client, sScrollStats, 256);
+	char[] sScrollStats = new char[300];
+	GetScrollStatsFormatted(client, sScrollStats, 300);
 
-	ReplyToCommand(client, "%s", sScrollStats);
+	ReplyToCommand(client, "Scroll stats for %N: %s", target, sScrollStats);
 
 	return Plugin_Handled;
 }
 
 void GetScrollStatsFormatted(int client, char[] buffer, int maxlength)
 {
-	FormatEx(buffer, maxlength, "Scroll stats for %N (%.02f%% perfs, %d sampled jumps): {", client, GetPerfectJumps(client), GetSampledJumps(client));
+	FormatEx(buffer, maxlength, "%d%% perfs, %d sampled jumps: {", client, GetPerfectJumps(client), GetSampledJumps(client));
 
 	int iSize = gA_JumpStats[client].Length;
 	int iEnd = (iSize >= SAMPLE_SIZE)? (iSize - SAMPLE_SIZE):0;
@@ -265,7 +265,7 @@ int GetSampledJumps(int client)
 	return (iSize - iEnd);
 }
 
-float GetPerfectJumps(int client)
+int GetPerfectJumps(int client)
 {
 	int iPerfs = 0;
 	int iSize = gA_JumpStats[client].Length;
@@ -280,12 +280,12 @@ float GetPerfectJumps(int client)
 		}
 	}
 
-	if(iPerfs == 0 || iTotalJumps == 0) // Don't throw a divide-by-zero error.
+	if(iTotalJumps == 0) // Don't throw a divide-by-zero error.
 	{
-		return 0.0;
+		return 0;
 	}
 
-	return (float(iPerfs) / iTotalJumps) * 100.0;
+	return (iPerfs / iTotalJumps) * 100;
 }
 
 public Action OnPlayerRunCmd(int client, int &buttons)
@@ -514,7 +514,7 @@ int Abs(int num)
 
 void AnalyzeStats(int client)
 {
-	float fPerfs = GetPerfectJumps(client);
+	int iPerfs = GetPerfectJumps(client);
 
 	// "Pattern analysis"
 	int iVeryHighNumber = 0;
@@ -578,65 +578,65 @@ void AnalyzeStats(int client)
 
 	bool bTriggered = true;
 
-	char[] sScrollStats = new char[256];
-	GetScrollStatsFormatted(client, sScrollStats, 256);
+	char[] sScrollStats = new char[300];
+	GetScrollStatsFormatted(client, sScrollStats, 300);
 
 	// Ugly code below, I know.
-	if(fPerfs >= 91.0)
+	if(iPerfs >= 91)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC1 ... "): %s", client, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_DEFINITIVE, DESC1);
 	}
 
-	else if(fPerfs >= 87.0 && (iSameAsNext >= 13 || iCloseToNext >= 18))
+	else if(iPerfs >= 87 && (iSameAsNext >= 13 || iCloseToNext >= 18))
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC2 ... "): %s", client, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_DEFINITIVE, DESC2);
 	}
 
-	else if(fPerfs >= 85.0 && iSameAsNext >= 13)
+	else if(iPerfs >= 85 && iSameAsNext >= 13)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC3 ... "): %s", client, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_DEFINITIVE, DESC3);
 	}
 
-	else if(fPerfs >= 80.0 && iSameAsNext >= 15)
+	else if(iPerfs >= 80 && iSameAsNext >= 15)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC4 ... "): %s", client, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_HIGH, DESC4);
 	}
 
-	else if(fPerfs >= 75.0 && iVeryHighNumber >= 4 && iSameAsNext >= 3 && iCloseToNext >= 10)
+	else if(iPerfs >= 75 && iVeryHighNumber >= 4 && iSameAsNext >= 3 && iCloseToNext >= 10)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC5 ... "): %s", client, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_HIGH, DESC5);
 	}
 
-	else if(fPerfs >= 85.0 && iCloseToNext >= 16)
+	else if(iPerfs >= 85 && iCloseToNext >= 16)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC6 ... "): %s", client, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_HIGH, DESC6);
 	}
 
-	else if(fPerfs >= 40.0 && iLowBefores >= 40)
+	else if(iPerfs >= 40 && iLowBefores >= 45)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC7 ... ") (%d): %s", client, iLowBefores, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_HIGH_NOKICK, DESC7);
 	}
 
-	else if(fPerfs >= 55.0 && iSameBeforeAfter >= 25)
+	else if(iPerfs >= 55 && iSameBeforeAfter >= 25)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC8 ... ") (bf %d | af %d | bfaf %d): %s", client, iLowBefores, iLowAfters, iSameBeforeAfter, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_HIGH_NOKICK, DESC8);
 	}
 
-	else if(fPerfs >= 40.0 && iLowAfters >= 40)
+	else if(iPerfs >= 40 && iLowAfters >= 45)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC9 ... ") (%d): %s", client, iLowAfters, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_HIGH_NOKICK, DESC9);
 	}
 
-	else if(iVeryHighNumber >= 15 && (iCloseToNext >= 13 || fPerfs >= 80.0))
+	else if(iVeryHighNumber >= 15 && (iCloseToNext >= 13 || iPerfs >= 80))
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC10 ... "): %s", client, sScrollStats);
 		Oryx_Trigger(client, TRIGGER_HIGH, DESC10);

--- a/addons/sourcemod/scripting/oryx-scroll.sp
+++ b/addons/sourcemod/scripting/oryx-scroll.sp
@@ -303,6 +303,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 	return SetupMove(client, buttons);
 }
 
+#if defined bhoptimer
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style, any stylesettings[STYLESETTINGS_SIZE])
 {
 	// Ignore autobhop styles.
@@ -322,6 +323,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 	return SetupMove(client, buttons);
 }
+#endif
 
 void ResetStatsArray(int client)
 {

--- a/addons/sourcemod/scripting/oryx-scroll.sp
+++ b/addons/sourcemod/scripting/oryx-scroll.sp
@@ -621,7 +621,7 @@ void AnalyzeStats(int client)
 	else if(iPerfs >= 40 && iLowBefores >= 45)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC7 ... ") (%d): %s", client, iLowBefores, sScrollStats);
-		Oryx_Trigger(client, TRIGGER_HIGH_NOKICK, DESC7);
+		Oryx_Trigger(client, TRIGGER_MEDIUM, DESC7);
 	}
 
 	else if(iPerfs >= 55 && iSameBeforeAfter >= 25)
@@ -633,7 +633,7 @@ void AnalyzeStats(int client)
 	else if(iPerfs >= 40 && iLowAfters >= 45)
 	{
 		LogToFileEx(gS_LogPath, "%L - (" ... DESC9 ... ") (%d): %s", client, iLowAfters, sScrollStats);
-		Oryx_Trigger(client, TRIGGER_HIGH_NOKICK, DESC9);
+		Oryx_Trigger(client, TRIGGER_LOW, DESC9);
 	}
 
 	else if(iVeryHighNumber >= 15 && (iCloseToNext >= 13 || iPerfs >= 80))

--- a/addons/sourcemod/scripting/oryx-scroll.sp
+++ b/addons/sourcemod/scripting/oryx-scroll.sp
@@ -236,7 +236,7 @@ public Action Command_PrintScrollStats(int client, int args)
 
 void GetScrollStatsFormatted(int client, char[] buffer, int maxlength)
 {
-	FormatEx(buffer, maxlength, "%d%% perfs, %d sampled jumps: {", client, GetPerfectJumps(client), GetSampledJumps(client));
+	FormatEx(buffer, maxlength, "%d%% perfs, %d sampled jumps: {", GetPerfectJumps(client), GetSampledJumps(client));
 
 	int iSize = gA_JumpStats[client].Length;
 	int iEnd = (iSize >= SAMPLE_SIZE)? (iSize - SAMPLE_SIZE):0;
@@ -259,6 +259,11 @@ void GetScrollStatsFormatted(int client, char[] buffer, int maxlength)
 
 int GetSampledJumps(int client)
 {
+	if(gA_JumpStats[client] == null)
+	{
+		return 0;
+	}
+
 	int iSize = gA_JumpStats[client].Length;
 	int iEnd = (iSize >= SAMPLE_SIZE)? (iSize - SAMPLE_SIZE):0;
 
@@ -285,7 +290,7 @@ int GetPerfectJumps(int client)
 		return 0;
 	}
 
-	return (iPerfs / iTotalJumps) * 100;
+	return RoundToZero((float(iPerfs) / iTotalJumps) * 100);
 }
 
 public Action OnPlayerRunCmd(int client, int &buttons)

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -186,11 +186,6 @@ public void OnLibraryRemoved(const char[] name)
 	}
 }
 
-bool EnoughBASHData(int client)
-{
-	return gA_StrafeHistory[client].Length >= SAMPLE_SIZE;
-}
-
 int GetSampledStrafes(int client)
 {
 	if(gA_StrafeHistory[client] == null)

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -94,6 +94,14 @@ public void OnPluginStart()
 	{
 		OnLibraryAdded("dhooks");
 	}
+
+	for(int i = 1; i <= MaxClients; i++)
+	{
+		if(IsClientInGame(i))
+		{
+			OnClientPutInServer(i);
+		}
+	}
 }
 
 public MRESReturn DHook_Teleport(int pThis, Handle hReturn)
@@ -155,14 +163,6 @@ public void OnLibraryAdded(const char[] name)
 				if(GetEngineVersion() == Engine_CSGO)
 				{
 					DHookAddParam(gH_Teleport, HookParamType_Bool);
-				}
-
-				for(int i = 1; i <= MaxClients; i++)
-				{
-					if(IsClientInGame(i))
-					{
-						OnClientPutInServer(i);
-					}
 				}
 			}
 
@@ -315,10 +315,19 @@ Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 	*/
 	if((GetEntityFlags(client) & FL_ONGROUND) == 0)
 	{
-		if((buttons & (IN_MOVELEFT | IN_MOVERIGHT)) != (IN_MOVELEFT | IN_MOVERIGHT))
+		// WARNING: UGLY CODE.
+		if((buttons & (IN_MOVELEFT | IN_MOVERIGHT)) != (IN_MOVELEFT | IN_MOVERIGHT) ||
+			(buttons & (IN_FORWARD | IN_BACK)) != (IN_FORWARD | IN_BACK))
 		{
-			if(((buttons & IN_MOVELEFT) > 0 && ((gI_PreviousButtons[client] & IN_MOVERIGHT) > 0 && (gI_PreviousButtons[client] & IN_MOVELEFT) > 0) || (gI_PreviousButtons[client] & IN_MOVELEFT) == 0) &&
-				((buttons & IN_MOVERIGHT) > 0 && ((gI_PreviousButtons[client] & IN_MOVERIGHT) > 0 && (gI_PreviousButtons[client] & IN_MOVELEFT) > 0) || (gI_PreviousButtons[client] & IN_MOVERIGHT) == 0))
+			if( // A/D
+				((((buttons & IN_MOVELEFT) > 0 && (gI_PreviousButtons[client] & IN_MOVELEFT) == 0) ||
+				((buttons & IN_MOVERIGHT) > 0 && (gI_PreviousButtons[client] & IN_MOVERIGHT) == 0)) ||
+				((gI_PreviousButtons[client] & IN_MOVERIGHT) > 0 && (gI_PreviousButtons[client] & IN_MOVELEFT) > 0)) ||
+
+				// S/W
+				((((buttons & IN_FORWARD) > 0 && (gI_PreviousButtons[client] & IN_FORWARD) == 0) ||
+				((buttons & IN_BACK) > 0 && (gI_PreviousButtons[client] & IN_BACK) == 0)) ||
+				((gI_PreviousButtons[client] & IN_BACK) > 0 && (gI_PreviousButtons[client] & IN_FORWARD) > 0)))
 			{
 				gB_KeyChanged[client] = true;
 				gI_KeyTransitionTick[client] = gI_AbsTicks[client];

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -56,8 +56,8 @@ ArrayList gA_StrafeHistory[MAXPLAYERS+1];
 
 float gF_PreviousOptimizedAngle[MAXPLAYERS+1];
 float gF_PreviousAngle[MAXPLAYERS+1];
+float gF_PreviousDeltaAngleAbs[MAXPLAYERS+1];
 float gF_PreviousDeltaAngle[MAXPLAYERS+1];
-float gF_PrevDeltaAngle2[MAXPLAYERS+1];
 
 int gI_AbsTicks[MAXPLAYERS+1];
 int gI_PreviousButtons[MAXPLAYERS+1];
@@ -346,11 +346,11 @@ Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 			}
 		}
 
-		// TODO: this is possibly wrong
-		if(fDeltaAngleAbs != 0.0 &&
-			((fDeltaAngle < 0.0 && gF_PrevDeltaAngle2[client] > 0.0) ||
-				(fDeltaAngle > 0.0 && gF_PrevDeltaAngle2[client] < 0.0) ||
-				gF_PreviousDeltaAngle[client] == 0.0) && !gB_DirectionChanged[client])
+		if(!gB_DirectionChanged[client] &&
+			(fDeltaAngleAbs != 0.0 &&
+			((fDeltaAngle < 0.0 && gF_PreviousDeltaAngle[client] > 0.0) ||
+			(fDeltaAngle > 0.0 && gF_PreviousDeltaAngle[client] < 0.0) ||
+			gF_PreviousDeltaAngleAbs[client] == 0.0)))
 		{
 			gB_DirectionChanged[client] = true;
 			gI_AngleTransitionTick[client] = gI_AbsTicks[client];
@@ -442,7 +442,7 @@ Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 	if(iLR == (IN_LEFT | IN_RIGHT) || iLR == 0)
 	{
 		// +left/right
-		if(Oryx_WithinThreshold(fDeltaAngleAbs, gF_PreviousDeltaAngle[client], (gF_PreviousDeltaAngle[client] / 128.0)))
+		if(Oryx_WithinThreshold(fDeltaAngleAbs, gF_PreviousDeltaAngleAbs[client], (gF_PreviousDeltaAngleAbs[client] / 128.0)))
 		{
 			if((iFlags & FL_ONGROUND) == 0)
 			{
@@ -493,8 +493,8 @@ Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 	
 	gI_PreviousButtons[client] = buttons;
 	gF_PreviousOptimizedAngle[client] = ArcSine(30.0 / fSpeed) * 57.29577951308;
-	gF_PreviousDeltaAngle[client] = fDeltaAngleAbs;
-	gF_PrevDeltaAngle2[client] = fDeltaAngle;
+	gF_PreviousDeltaAngleAbs[client] = fDeltaAngleAbs;
+	gF_PreviousDeltaAngle[client] = fDeltaAngle;
 
 	return Plugin_Continue;
 }
@@ -523,7 +523,7 @@ void AnalyzeBASHStats(int client)
 	// Average tick difference.
 	if(iTickDifference < 9)
 	{
-		Oryx_Trigger(client, TRIGGER_HIGH, DESC6);
+		Oryx_Trigger(client, TRIGGER_MEDIUM, DESC6);
 		gI_BASHTriggerCountdown[client] = 35;
 	}
 

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -266,6 +266,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	return SetupMove(client, buttons, angles, vel);
 }
 
+#if defined bhoptimer
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style)
 {
 	// Ignore whitelisted styles.
@@ -279,6 +280,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 	return SetupMove(client, buttons, angles, vel);
 }
+#endif
 
 Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 {

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -258,7 +258,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 		return Plugin_Continue;
 	}
 
-	return SetupMove(client, buttons, angles);
+	return SetupMove(client, buttons, angles, vel);
 }
 
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style)
@@ -272,10 +272,10 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 		return Plugin_Continue;
 	}
 
-	return SetupMove(client, buttons, angles);
+	return SetupMove(client, buttons, angles, vel);
 }
 
-Action SetupMove(int client, int &buttons, float angles[3])
+Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 {
 	if(!IsPlayerAlive(client) || IsFakeClient(client) || !IsLegalMoveType(client))
 	{
@@ -360,7 +360,6 @@ Action SetupMove(int client, int &buttons, float angles[3])
 			gI_StrafeHistoryIndex[client] = 0;
 		}
 		
-		#if defined bhoptimer
 		// This isn't for BASH.
 		if((buttons & IN_LEFT) > 0)
 		{
@@ -372,15 +371,11 @@ Action SetupMove(int client, int &buttons, float angles[3])
 			gB_RightThisJump[client] = true;
 		}
 
-		if(gB_LeftThisJump[client] && gB_RightThisJump[client] && Shavit_GetTimerStatus(client) == Timer_Running)
+		if(gB_LeftThisJump[client] && gB_RightThisJump[client])
 		{
-			Shavit_StopTimer(client);
-			PrintToChat(client, "Your timer has been stopped for using +left and +right in a single jump.");
-
-			gB_LeftThisJump[client] = false;
-			gB_RightThisJump[client] = false;
+			vel[0] = 0.0;
+			vel[1] = 0.0;
 		}
-		#endif
 	}
 
 	else
@@ -388,11 +383,9 @@ Action SetupMove(int client, int &buttons, float angles[3])
 		gB_KeyChanged[client] = false;
 		gB_DirectionChanged[client] = false;
 		
-		#if defined bhoptimer
 		// This isn't for BASH.
 		gB_LeftThisJump[client] = false;
 		gB_RightThisJump[client] = false;
-		#endif
 	}
 
 	float fAbsVelocity[3];

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -29,6 +29,7 @@ Handle gH_Forwards_OnTrigger = null;
 
 char gS_LogPath[PLATFORM_MAX_PATH];
 char gS_BeepSound[PLATFORM_MAX_PATH];
+bool gB_NoSound = false;
 
 bool gB_Testing[MAXPLAYERS+1];
 bool gB_Locked[MAXPLAYERS+1];
@@ -170,6 +171,7 @@ public int Native_OryxTrigger(Handle plugin, int numParams)
 	if(level == TRIGGER_LOW)
 	{
 		strcopy(sLevel, 16, "LOW");
+		gB_NoSound = true; // Don't play the annoying beep sound for LOW detections.
 	}
 
 	else if(level == TRIGGER_MEDIUM)
@@ -250,14 +252,19 @@ public int Native_PrintToAdmins(Handle plugin, int numParams)
 		{
 			PrintToChat(i, "%s\x04[ORYX]\x01 %s", (gEV_Type == Engine_CSGO)? " ":"", sMessage);
 
-			if(gEV_Type == Engine_CSS || gEV_Type == Engine_TF2)
+			if(gB_NoSound)
 			{
-				EmitSoundToClient(i, gS_BeepSound);
-			}
+				if(gEV_Type == Engine_CSS || gEV_Type == Engine_TF2)
+				{
+					EmitSoundToClient(i, gS_BeepSound);
+				}
 
-			else
-			{
-				ClientCommand(i, "play */%s", gS_BeepSound);
+				else
+				{
+					ClientCommand(i, "play */%s", gS_BeepSound);
+				}
+
+				gB_NoSound = false;
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -36,7 +36,7 @@ bool gB_Locked[MAXPLAYERS+1];
 
 public Plugin myinfo = 
 {
-	name = "ORYX Anti-Cheat",
+	name = "ORYX bunnyhop anti-cheat",
 	author = "Rusty, shavit",
 	description = "Cheat detection interface.",
 	version = ORYX_VERSION,

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -252,7 +252,7 @@ public int Native_PrintToAdmins(Handle plugin, int numParams)
 		{
 			PrintToChat(i, "%s\x04[ORYX]\x01 %s", (gEV_Type == Engine_CSGO)? " ":"", sMessage);
 
-			if(gB_NoSound)
+			if(!gB_NoSound)
 			{
 				if(gEV_Type == Engine_CSS || gEV_Type == Engine_TF2)
 				{
@@ -263,9 +263,9 @@ public int Native_PrintToAdmins(Handle plugin, int numParams)
 				{
 					ClientCommand(i, "play */%s", gS_BeepSound);
 				}
-
-				gB_NoSound = false;
 			}
+
+			gB_NoSound = false;
 		}
 	}
 }

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -45,7 +45,7 @@ public Plugin myinfo =
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
 	CreateNative("Oryx_Trigger", Native_OryxTrigger);
-	CreateNative("Oryx_WithinFlThresh", Native_WithinFlThresh);
+	CreateNative("Oryx_WithinThreshold", Native_WithinThreshold);
 	CreateNative("Oryx_PrintToAdmins", Native_PrintToAdmins);
 	CreateNative("Oryx_PrintToAdminsConsole", Native_PrintToAdminsConsole);
 
@@ -230,13 +230,13 @@ public int Native_OryxTrigger(Handle plugin, int numParams)
 	return view_as<int>(result);
 }
 
-public int Native_WithinFlThresh(Handle plugin, int numParams)
+public int Native_WithinThreshold(Handle plugin, int numParams)
 {
-	float f2 = GetNativeCell(2);
-	float t = f2 / GetNativeCell(3);
 	float f1 = GetNativeCell(1);
+	float f2 = GetNativeCell(2);
+	float threshold = GetNativeCell(3);
 
-	return (f1 > (f2 - t) && f1 < (f2 + t));
+	return view_as<int>(FloatAbs(f1 - f2) <= threshold);
 }
 
 public int Native_PrintToAdmins(Handle plugin, int numParams)


### PR DESCRIPTION
* Blocked +left/+right in the same jump. It's a better solution rather than stopping the player's timer.
* Fixed scroll module logs and `scroll_stats`'s output.
* Adjusted sanity module to produce less false positives. I know that during server lag, it might improperly detect players. Hit me up if you have any ideas on how to fix it.
* Added `Oryx_OnTrigger` as requested in #4.
* Adjusted trigger levels for bf/af detections in scroll module.
* Fixed improper strafe hack detections for SW.
* Fixed Prestrafe Tool and Acute TR Formatter ('strafe optimizer') detections not working, due to `Oryx_WithinFlThresh` being originally broken.
* Changed scroll module to not count the very first jump in the bunnyhop streak as it lacks information (such as if it's a perfect jump).
* Removed beep sound from LOW level detections.
* Rewrote the way strafe module saves and interacts with strafe history.
* Disallowed raw input detections from triggering more than once per player connection.
* Added `+klook` (for illegal LJ binds) detection.