### PR TITLE
v1.3

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,32 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "SourcePawn Compile",
+            "type": "shell",
+            "command": "E:\\scripting\\spcomp.exe",
+            "args": [
+                "'${file}'",
+                "-i=E:\\scripting\\include",
+                "-D=E:\\css-ds\\cstrike\\addons\\sourcemod\\plugins",
+            ],
+            "problemMatcher": {
+                "owner": "sp",
+                "fileLocation": "absolute",
+                "pattern": {
+                    "regexp": "^(.*)\\((.+)\\)\\s:\\s(((warning|error|fatal error)\\s\\d+):\\s.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "severity": 5,
+                    "message": 3
+                }
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Unsynchronised movement | Wish velocity does not align with with the player's bu
 Invalid wish velocity | Wish velocity can only be specific values ([link 1](https://mxr.alliedmods.net/hl2sdk-css/source/game/client/in_main.cpp#557), [link 2](https://mxr.alliedmods.net/hl2sdk-css/source/game/client/in_main.cpp#842)) | oryx-sanity
 Wish velocity is too high | Wish velocity exceeds the default `cl_forwardspeed` or `cl_sidespeed` settings | oryx-sanity
 Wrong mouse inputs | Raw input has discrepancies with the view angles' yaw delta | oryx-sanity
+Invalid buttons/wishspeeds | Buttons and wishspeeds do not match | oryx-sanity
 Scripted jumps (havg) | Too many perfect jumps indicates a potential jump script usage | oryx-scroll
 Scripted jumps (havgp, patt1, patt2, wpatt, wpatt2) | Too many perfect jumps while maintaining obviously weird scroll stats | oryx-scroll
 Scripted jumps (nobf, bf-af, noaf) | Inhuman stats for scrolls before touching the ground and after jumping | oryx-scroll

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a fork of Oryx, the bunnyhop anticheat written by Rusty/Nolan-O. The REA
 The main differences from the original version are:
 
 * I have supported CS:GO and TF2.
-* I edited the plugin to work with [bhoptimer](https://github.com/shavitush/bhoptimer). [bTimes](https://github.com/Nolan-O/bTimes) support has been dropped.
+* I edited the plugin to work with [bhoptimer](https://github.com/shavitush/bhoptimer). [bTimes](https://github.com/Nolan-O/bTimes) support is kept, and bTimes2 support has been added too. Note that bTimes is not free software, so I cannot actively maintain the support for it.
 * [smlib](https://github.com/splewis/smlib) is not a dependency anymore.
 * Optimizations have been applied.
 * Cleaned the code where I could. Most plugins will look as if they were rewritten, as I don't like the way Rusty wrote them in first place.
@@ -26,8 +26,6 @@ Rusty's notes:
 You need DHooks to build. You also need DHooks on your server for `oryx-sanity` and `oryx-strafe` to work.  
 It depends on gamedata from SDKTools therefore shouldn't break unless your server is out of date.
 
-All you need to do is make sure you've specified your timer in oryx.inc by defining either `notimer` or `bhoptimer`. Build each file manually with the SourceMod compiler, like usual.  
-If `bhoptimer` is defined, you will need [bhoptimer](https://github.com/shavitush/bhoptimer)'s include file.  
 Send a pull request if you want to support other timers.
 
 # Documentation  
@@ -73,7 +71,7 @@ Scroll macro (highn) | Way too many scroll inputs per jump, giving away the play
 Scroll cheat (interval, ticks) | Analysis on interval between scrolls ~~and ticks on ground~~ (WIP). These methods are at low detection level due to the nature of UDP causing packets to not be in the correct order all the time | oryx-scroll
 
 **Note**: `oryx-sanity` **will** cause false positives with gamepads and controllers.  
-**Note 2**: If using [bhoptimer](https://github.com/shavitush/bhoptimer), add `oryx_bypass` to the special string. This setting will disable the sanity, strafe, and movement config anticheats from triggering on the style. For example:
+**Note 2**: If using [bhoptimer](https://github.com/shavitush/bhoptimer), add `oryx_bypass` to the special string. This setting will disable the anticheats from triggering on the style. For example:
 
 ```
 "7"
@@ -100,6 +98,9 @@ Scroll cheat (interval, ticks) | Analysis on interval between scrolls ~~and tick
 	"specialstring"		"100gainstrafe;tas;oryx_bypass"
 }
 ```
+
+**Note 3**: For [bTimes v1.8.3](https://github.com/Nolan-O/bTimes), change the `special` flag to `oryx_bypass` to disable the anticheats from triggering.  
+**Note 4**: For bTimes2, TAS (while editing) will be automatically excluded from the anticheat.
 
 Docs on natives are found in `oryx.inc`, using the SourceMod self-documenting style.
 

--- a/addons/sourcemod/scripting/include/bTimes-tas.inc
+++ b/addons/sourcemod/scripting/include/bTimes-tas.inc
@@ -1,0 +1,38 @@
+#if defined _tas_included
+  #endinput
+#endif
+#define _tas_included
+
+native bool      TAS_InEditMode(int client);
+
+native bool      TAS_IsPaused(int client);
+
+native ArrayList TAS_GetRunHandle(int client);
+
+native int       TAS_GetCurrentFrame(int client);
+
+forward void OnTASPauseChanged(int client, bool paused);
+
+forward void OnTASFrameRecorded(int client, int frame);
+
+public SharedPlugin __pl_tas = 
+{
+	name = "tas",
+	file = "bTimes-tas.smx",
+#if defined REQUIRE_PLUGIN
+	required = 1,
+#else
+	required = 0,
+#endif
+};
+
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_tas_SetNTVOptional()
+{
+	MarkNativeAsOptional("TAS_InEditMode");
+	MarkNativeAsOptional("TAS_IsPaused");
+	MarkNativeAsOptional("TAS_GetRunHandle");
+	MarkNativeAsOptional("TAS_GetCurrentFrame");
+}
+#endif

--- a/addons/sourcemod/scripting/include/bTimes-timer_hack.inc
+++ b/addons/sourcemod/scripting/include/bTimes-timer_hack.inc
@@ -1,0 +1,89 @@
+#if defined _btimes_timer_included
+  #endinput
+#endif
+#define _btimes_timer_included
+
+enum styleConfig
+{
+	String:Name[32],
+	String:Name_Short[32],
+	bool:Enabled,
+	bool:TempEnabled,
+	bool:AllowType[2],
+	bool:Freestyle,
+	bool:Freestyle_Unrestrict,
+	bool:Freestyle_EzHop,
+	bool:Freestyle_Auto,
+	bool:Auto,
+	bool:EzHop,
+	Float:Gravity,
+	Float:RunSpeed,
+	Float:MaxVel,
+	Float:MinFps,
+	bool:CalcSync,
+	bool:Prevent_Left,
+	bool:Prevent_Right,
+	bool:Prevent_Back,
+	bool:Prevent_Forward,
+	bool:Require_Left,
+	bool:Require_Right,
+	bool:Require_Back,
+	bool:Require_Forward,
+	bool:Hud_Style,
+	bool:Hud_Strafes,
+	bool:Hud_Jumps,
+	bool:Count_Left_Strafe,
+	bool:Count_Right_Strafe,
+	bool:Count_Back_Strafe,
+	bool:Count_Forward_Strafe,
+	bool:Ghost_Use[2],
+	bool:Ghost_Save[2],
+	Float:PreSpeed,
+	Float:SlowedSpeed,
+	bool:Special,
+	String:Special_Key[32],
+	bool:GunJump,
+	String:GunJump_Weapon[64],
+	bool:UnrealPhys,
+	AirAcceleration,
+	bool:EnableBunnyhopping,
+	StyleConfig
+};
+
+/*
+* Gets a client's style (Normal, Sideways, etc..).
+* 
+* @param client        Client index
+* 
+* @return              The client's style.
+*/
+native int GetClientStyle(int client);
+
+/*
+* Gets the complete configuration for a specified style.
+* 
+* @param Style         The style to get a configuration for.
+* @param Properties    The buffer to store all the style properties, (properties are listed in the StyleConfig enum)
+* 
+* @return              True if the style exists, false otherwise.
+*/
+native bool Style_GetConfig(int Style, any Properties[StyleConfig]);
+
+public SharedPlugin __pl_btimes_timer =
+{
+	name = "timer",
+	file = "bTimes-timer.smx",
+#if defined REQUIRE_PLUGIN
+	required = 1
+#else
+	required = 0
+#endif
+};
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_btimes_timer_SetNTVOptional()
+{
+	MarkNativeAsOptional("GetClientStyle");
+	MarkNativeAsOptional("Style_GetConfig");
+}
+#endif

--- a/addons/sourcemod/scripting/include/oryx.inc
+++ b/addons/sourcemod/scripting/include/oryx.inc
@@ -79,7 +79,7 @@ native Action Oryx_Trigger(int client, int level, const char[] cheat);
  * @param msg 					Pre-formatted message to print to admins.
  * @noreturn
  */
-native void Oryx_PrintToAdmins(char[] msg);
+native void Oryx_PrintToAdmins(const char[] msg);
 
 /**
  * Prints a message to admins' console.
@@ -87,7 +87,16 @@ native void Oryx_PrintToAdmins(char[] msg);
  * @param msg 					Pre-formatted message to print to admins.
  * @noreturn
  */
-native void Oryx_PrintToAdminsConsole(char[] msg);
+native void Oryx_PrintToAdminsConsole(const char[] msg);
+
+/**
+ * Logs an entry to Oryx's log file.
+ *
+ * @param format					Formattiing rules.
+ * @param any						Variable number of format parameters.
+ * @noreturn
+ */
+native void Oryx_LogMessage(const char[] format, any ...);
 
 /**
  * Checks if f1 is inbetween a specified threshold of f12.

--- a/addons/sourcemod/scripting/include/oryx.inc
+++ b/addons/sourcemod/scripting/include/oryx.inc
@@ -76,23 +76,25 @@ native Action Oryx_Trigger(int client, int level, const char[] cheat);
 /**
  * Prints a message to admins' chat.
  *
- * @param msg 					Pre-formatted message to print to admins.
+ * @param format					Formatting rules.
+ * @param any						Variable number of format parameters.
  * @noreturn
  */
-native void Oryx_PrintToAdmins(const char[] msg);
+native void Oryx_PrintToAdmins(const char[] format, any ...);
 
 /**
  * Prints a message to admins' console.
  *
- * @param msg 					Pre-formatted message to print to admins.
+ * @param format					Formatting rules.
+ * @param any						Variable number of format parameters.
  * @noreturn
  */
-native void Oryx_PrintToAdminsConsole(const char[] msg);
+native void Oryx_PrintToAdminsConsole(const char[] format, any ...);
 
 /**
  * Logs an entry to Oryx's log file.
  *
- * @param format					Formattiing rules.
+ * @param format					Formatting rules.
  * @param any						Variable number of format parameters.
  * @noreturn
  */

--- a/addons/sourcemod/scripting/include/oryx.inc
+++ b/addons/sourcemod/scripting/include/oryx.inc
@@ -21,7 +21,7 @@
 #endif
 #define _oryx_included
 
-#define ORYX_VERSION "1.2"
+#define ORYX_VERSION "1.3"
 
 /**
 * List of current detection descriptions:
@@ -47,11 +47,6 @@ enum
 	TRIGGER_DEFINITIVE,		// Non-skill-based detection type. 100% sure detection.
 	TRIGGER_TEST			// Allows you to develop new detections on live servers with minimal side effects.
 };
-
-/**
- * Acceptable timers: "bhoptimer" & "notimer"
- */
-#define bhoptimer
 
 /**
  * Called when Oryx gets triggered on a client.
@@ -111,6 +106,17 @@ native void Oryx_LogMessage(const char[] format, any ...);
 native bool Oryx_WithinThreshold(float f1, float f2, float threshold);
 
 /**
+ * Checks if the player has permissions to bypass Oryx.
+ * Will return false if `oryx_allow_bypass` is set to 0.
+ * With bhoptimer or bTimes v1.8.3, will return true for styles with the `oryx_bypass` special flag.
+ * For bTimes2, will return true if the player is in edit mode (rewind/fastforward etc).
+ *
+ * @param client				Client index.
+ * @return 						True if the player can bypass the anticheat.
+ */
+native bool Oryx_CanBypass(int client);
+
+/**
  * A tiny function to veify if the player fits gameplay.
  *
  * @param client				Client entity index.
@@ -125,3 +131,26 @@ stock bool IsLegalMoveType(int client, bool water = true)
 		(GetEntityFlags(client) & FL_ATCONTROLS) == 0 &&
 		(iMoveType == MOVETYPE_WALK || iMoveType == MOVETYPE_ISOMETRIC || iMoveType == MOVETYPE_LADDER);
 }
+
+public SharedPlugin __pl_oryx =
+{
+	name = "oryx",
+	file = "oryx.smx",
+#if defined REQUIRE_PLUGIN
+	required = 1
+#else
+	required = 0
+#endif
+};
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_oryx_SetNTVOptional()
+{
+	MarkNativeAsOptional("Oryx_CanBypass");
+	MarkNativeAsOptional("Oryx_LogMessage");
+	MarkNativeAsOptional("Oryx_PrintToAdmins");
+	MarkNativeAsOptional("Oryx_PrintToAdminsConsole");
+	MarkNativeAsOptional("Oryx_Trigger");
+	MarkNativeAsOptional("Oryx_WithinThreshold");
+}
+#endif

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -23,7 +23,7 @@
 #endif
 #define _shavit_included
 
-#define SHAVIT_VERSION "1.5b"
+#define SHAVIT_VERSION "2.0.2"
 #define STYLE_LIMIT 256
 #define MAX_ZONES 64
 
@@ -1102,11 +1102,21 @@ native StringMap Shavit_GetMapTiers();
  * This native will auto-assign colors and a chat prefix.
  *
  * @param client					Client index.
- * @param format					Formattiing rules.
+ * @param format					Formatting rules.
  * @param any						Variable number of format parameters.
  * @return							PrintToChat()
  */
 native int Shavit_PrintToChat(int client, const char[] format, any ...);
+
+/**
+ * Logs an entry to bhoptimer's log file.
+ * (addons/sourcemod/logs/shavit.log)
+ *
+ * @param format					Formatting rules.
+ * @param any						Variable number of format parameters.
+ * @noreturn
+ */
+native void Shavit_LogMessage(const char[] format, any ...);
 
 // same as Shavit_PrintToChat() but loops through the whole server
 // code stolen from the base halflife.inc file

--- a/addons/sourcemod/scripting/oryx-configcheck.sp
+++ b/addons/sourcemod/scripting/oryx-configcheck.sp
@@ -19,10 +19,8 @@
 #include <sourcemod>
 #include <oryx>
 
-#if defined bhoptimer
 #undef REQUIRE_PLUGIN
 #include <shavit>
-#endif
 
 #pragma newdecls required
 #pragma semicolon 1
@@ -39,9 +37,7 @@ int gI_LastDetection[MAXPLAYERS+1];
 
 int gI_PerfectConfigStreak[MAXPLAYERS+1];
 int gI_PreviousButtons[MAXPLAYERS+1];
-#if defined bhoptimer
 int gI_JumpsFromZone[MAXPLAYERS+1];
-#endif
 
 bool gB_Shavit = false;
 
@@ -72,9 +68,7 @@ public void OnClientPutInServer(int client)
 	gI_LastDetection[client] = 0;
 
 	gI_PerfectConfigStreak[client] = 0;
-	#if defined bhoptimer
 	gI_JumpsFromZone[client] = 0;
-	#endif
 }
 
 public void OnLibraryAdded(const char[] name)
@@ -134,25 +128,14 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	return SetupMove(client, buttons, vel);
 }
 
-#if defined bhoptimer
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style)
 {
-	// Ignore whitelisted styles.
-	char[] sSpecial = new char[32];
-	Shavit_GetStyleStrings(style, sSpecialString, sSpecial, 32);
-
-	if(StrContains(sSpecial, "oryx_bypass", false) != -1)
-	{
-		return Plugin_Continue;
-	}
-
 	return SetupMove(client, buttons, vel);
 }
-#endif
 
 Action SetupMove(int client, int &buttons, float vel[3])
 {
-	if(!IsPlayerAlive(client) || IsFakeClient(client))
+	if(Oryx_CanBypass(client))
 	{
 		return Plugin_Continue;
 	}
@@ -200,25 +183,25 @@ Action SetupMove(int client, int &buttons, float vel[3])
 		}
 	}
 	
-	#if defined bhoptimer
-	// Attempt at only sampling real gameplay (out of the start zone).
-	if(Shavit_InsideZone(client, Zone_Start, -1))
+	if(gB_Shavit)
 	{
-		gI_JumpsFromZone[client] = 0;
+		if(Shavit_InsideZone(client, Zone_Start, -1))
+		{
+			gI_JumpsFromZone[client] = 0;
 
-		return Plugin_Continue;
-	}
-	
-	if((iFlags & FL_ONGROUND) > 0 && (buttons & IN_JUMP) > 0)
-	{
-		gI_JumpsFromZone[client]++;
-	}
+			return Plugin_Continue;
+		}
 		
-	if(gI_JumpsFromZone[client] < 2)
-	{
-		return Plugin_Continue;
+		if((iFlags & FL_ONGROUND) > 0 && (buttons & IN_JUMP) > 0)
+		{
+			gI_JumpsFromZone[client]++;
+		}
+			
+		if(gI_JumpsFromZone[client] < 2)
+		{
+			return Plugin_Continue;
+		}
 	}
-	#endif
 	
 	if((iFlags & FL_ONGROUND) == 0)
 	{

--- a/addons/sourcemod/scripting/oryx-configcheck.sp
+++ b/addons/sourcemod/scripting/oryx-configcheck.sp
@@ -54,7 +54,7 @@ public void OnPluginStart()
 {
 	RegAdminCmd("config_streak", Command_ConfigStreak, ADMFLAG_BAN, "Print the config stat buffer for a given player.");
 
-	gCV_KLookDetection = CreateConVar("oryx-configcheck_klook", "1", "How to treat +klook usage?\n-1 - do not.\n0 - disable +klook.\n1 - disable + alert admins and log.\n2 - kick player.", 0, true, -1.0, true, 2.0);
+	gCV_KLookDetection = CreateConVar("oryx-configcheck_klook", "0", "How to treat +klook usage?\n-1 - do not.\n0 - disable +klook.\n1 - disable + alert admins and log.\n2 - kick player.", 0, true, -1.0, true, 2.0);
 	AutoExecConfig();
 
 	LoadTranslations("common.phrases");

--- a/addons/sourcemod/scripting/oryx-sanity.sp
+++ b/addons/sourcemod/scripting/oryx-sanity.sp
@@ -297,26 +297,27 @@ bool IsValidMove(float num)
 	// VERY minor optimization loss, but makes the code less annoying to read.
 	float speed = gF_FullPress;
 
-	// TODO: duck + shift in css
-
 	return (num == 0.0 || num == speed || num == (speed * 0.75) || num == (speed * 0.50) || num == (speed * 0.25));
 }
 
 bool DoButtonsMatchUp(int buttons, float forwardmove, float sidemove)
 {
 	float fHalf = (gF_FullPress * 0.5);
+	float fThreeQuarters = (gF_FullPress * 0.75);
 	int iAD = (buttons & (IN_MOVELEFT | IN_MOVERIGHT));
 
 	if(iAD == 0 || iAD == (IN_MOVELEFT | IN_MOVERIGHT))
 	{
-		if(sidemove != 0.0 && FloatAbs(sidemove) != fHalf)
+		float abs = FloatAbs(sidemove);
+
+		if(sidemove != 0.0 && abs != fHalf && abs != fThreeQuarters)
 		{
 			return false;
 		}
 	}
 
-	else if((iAD == IN_MOVELEFT && sidemove != -gF_FullPress && sidemove != -fHalf) ||
-			(iAD == IN_MOVERIGHT && sidemove != gF_FullPress && sidemove != fHalf))
+	else if((iAD == IN_MOVELEFT && sidemove != -gF_FullPress && sidemove != -fHalf && sidemove != fThreeQuarters) ||
+			(iAD == IN_MOVERIGHT && sidemove != gF_FullPress && sidemove != fHalf && sidemove != -fThreeQuarters))
 	{
 		return false;
 	}
@@ -325,14 +326,16 @@ bool DoButtonsMatchUp(int buttons, float forwardmove, float sidemove)
 
 	if(iSW == 0 || iSW == (IN_FORWARD | IN_BACK))
 	{
-		if(forwardmove != 0.0 && FloatAbs(forwardmove) != fHalf)
+		float abs = FloatAbs(forwardmove);
+
+		if(forwardmove != 0.0 && abs != fHalf && abs != fThreeQuarters)
 		{
 			return false;
 		}
 	}
 
-	else if((iSW == IN_FORWARD && forwardmove != gF_FullPress && forwardmove != fHalf) ||
-			(iSW == IN_BACK && forwardmove != -gF_FullPress && forwardmove != -fHalf))
+	else if((iSW == IN_FORWARD && forwardmove != gF_FullPress && forwardmove != fHalf && forwardmove != fThreeQuarters) ||
+			(iSW == IN_BACK && forwardmove != -gF_FullPress && forwardmove != -fHalf  && forwardmove != -fThreeQuarters))
 	{
 		return false;
 	}

--- a/addons/sourcemod/scripting/oryx-sanity.sp
+++ b/addons/sourcemod/scripting/oryx-sanity.sp
@@ -302,6 +302,7 @@ bool IsValidMove(float num)
 
 bool DoButtonsMatchUp(int buttons, float forwardmove, float sidemove)
 {
+	float fQuarter = (gF_FullPress * 0.25);
 	float fHalf = (gF_FullPress * 0.5);
 	float fThreeQuarters = (gF_FullPress * 0.75);
 	int iAD = (buttons & (IN_MOVELEFT | IN_MOVERIGHT));
@@ -310,7 +311,7 @@ bool DoButtonsMatchUp(int buttons, float forwardmove, float sidemove)
 	{
 		float abs = FloatAbs(sidemove);
 
-		if(sidemove != 0.0 && abs != fHalf && abs != fThreeQuarters)
+		if(sidemove != 0.0 && abs != fQuarter && abs != fHalf && abs != fThreeQuarters)
 		{
 			return false;
 		}
@@ -328,7 +329,7 @@ bool DoButtonsMatchUp(int buttons, float forwardmove, float sidemove)
 	{
 		float abs = FloatAbs(forwardmove);
 
-		if(forwardmove != 0.0 && abs != fHalf && abs != fThreeQuarters)
+		if(forwardmove != 0.0 && abs != fQuarter && abs != fHalf && abs != fThreeQuarters)
 		{
 			return false;
 		}

--- a/addons/sourcemod/scripting/oryx-scroll.sp
+++ b/addons/sourcemod/scripting/oryx-scroll.sp
@@ -225,7 +225,7 @@ public Action Command_PrintScrollStats(int client, int args)
 	}
 
 	char[] sScrollStats = new char[300];
-	GetScrollStatsFormatted(client, sScrollStats, 300);
+	GetScrollStatsFormatted(target, sScrollStats, 300);
 
 	ReplyToCommand(client, "Scroll stats for %N: %s", target, sScrollStats);
 

--- a/addons/sourcemod/scripting/oryx-scroll.sp
+++ b/addons/sourcemod/scripting/oryx-scroll.sp
@@ -21,10 +21,8 @@
 #include <sdktools>
 #include <oryx>
 
-#if defined bhoptimer
 #undef REQUIRE_PLUGIN
 #include <shavit>
-#endif
 
 #pragma newdecls required
 #pragma semicolon 1
@@ -303,7 +301,6 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 	return SetupMove(client, buttons);
 }
 
-#if defined bhoptimer
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style, any stylesettings[STYLESETTINGS_SIZE])
 {
 	// Ignore autobhop styles.
@@ -312,18 +309,8 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 		return Plugin_Continue;
 	}
 
-	// Ignore whitelisted styles.
-	char[] sSpecial = new char[32];
-	Shavit_GetStyleStrings(style, sSpecialString, sSpecial, 32);
-
-	if(StrContains(sSpecial, "oryx_bypass", false) != -1)
-	{
-		return Plugin_Continue;
-	}
-
 	return SetupMove(client, buttons);
 }
-#endif
 
 void ResetStatsArray(int client)
 {
@@ -364,7 +351,7 @@ float GetGroundDistance(int client)
 
 Action SetupMove(int client, int buttons)
 {
-	if(sv_autobunnyhopping != null && gB_AutoBunnyhopping)
+	if((sv_autobunnyhopping != null && gB_AutoBunnyhopping) || Oryx_CanBypass(client))
 	{
 		return Plugin_Continue;
 	}

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -542,7 +542,7 @@ void AnalyzeBASHStats(int client)
 		FormatStrafeStats(client, sStrafeStats, 256);
 
 		Oryx_PrintToAdminsConsole(sStrafeStats);
-		LogToFileEx(gS_LogPath, "%s", sStrafeStats);
+		LogToFileEx(gS_LogPath, "%L - %s", client, sStrafeStats);
 
 		return;
 	}
@@ -572,6 +572,6 @@ void AnalyzeBASHStats(int client)
 		FormatStrafeStats(client, sStrafeStats, 256);
 
 		Oryx_PrintToAdminsConsole(sStrafeStats);
-		LogToFileEx(gS_LogPath, "%s", sStrafeStats);
+		LogToFileEx(gS_LogPath, "%L - %s", client, sStrafeStats);
 	}
 }

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -21,10 +21,8 @@
 #include <oryx>
 #include <dhooks>
 
-#if defined bhoptimer
 #undef REQUIRE_PLUGIN
 #include <shavit>
-#endif
 
 #pragma newdecls required
 #pragma semicolon 1
@@ -307,25 +305,14 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	return SetupMove(client, buttons, angles, vel);
 }
 
-#if defined bhoptimer
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style)
 {
-	// Ignore whitelisted styles.
-	char[] sSpecial = new char[32];
-	Shavit_GetStyleStrings(style, sSpecialString, sSpecial, 32);
-
-	if(StrContains(sSpecial, "oryx_bypass", false) != -1)
-	{
-		return Plugin_Continue;
-	}
-
 	return SetupMove(client, buttons, angles, vel);
 }
-#endif
 
 Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 {
-	if(!IsPlayerAlive(client) || IsFakeClient(client))
+	if(Oryx_CanBypass(client))
 	{
 		return Plugin_Continue;
 	}

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -191,29 +191,30 @@ bool IsSurfing(int client)
 {
 	float fPosition[3];
 	GetClientAbsOrigin(client, fPosition);
-	Handle hTR = TR_TraceRayFilterEx(fPosition, view_as<float>({90.0, 0.0, 0.0}), MASK_PLAYERSOLID, RayType_Infinite, TRFilter_NoPlayers, client);
+
+	float fEnd[3];
+	fEnd = fPosition;
+	fEnd[2] -= 64.0;
+
+	float fMins[3];
+	GetEntPropVector(client, Prop_Send, "m_vecMins", fMins);
+
+	float fMaxs[3];
+	GetEntPropVector(client, Prop_Send, "m_vecMaxs", fMaxs);
+
+	Handle hTR = TR_TraceHullFilterEx(fPosition, fEnd, fMins, fMaxs, MASK_PLAYERSOLID, TRFilter_NoPlayers, client);
 
 	if(TR_DidHit(hTR))
 	{
-		float fGroundPosition[3];
 		float fNormal[3];
-
-		TR_GetEndPosition(fGroundPosition, hTR);
 		TR_GetPlaneNormal(hTR, fNormal);
 
 		delete hTR;
 
-		// It's safe to assume we're not surfing if we're much higher than the ramp.
-		//
 		// If the plane normal's Z axis is 0.7 or below (alternatively, -0.7 when upside-down) then it's a surf ramp.
 		// https://mxr.alliedmods.net/hl2sdk-css/source/game/server/physics_main.cpp#1059
 
-		if(GetVectorDistance(fPosition, fGroundPosition) >= 32.0 || !(-0.7 <= fNormal[2] <= 0.7))
-		{
-			return false;
-		}
-
-		return true;
+		return (-0.7 <= fNormal[2] <= 0.7);
 	}
 
 	delete hTR;

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -493,7 +493,7 @@ Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 
 				if(gI_SteadyAngleStreak[client] == 50)
 				{
-					Oryx_Trigger(client, TRIGGER_HIGH, DESC2);
+					Oryx_Trigger(client, TRIGGER_LOW, DESC2);
 
 					gI_SteadyAngleStreak[client] = 0;
 				}

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -327,10 +327,10 @@ Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 	* BASH remake
 	* Some of the logic may seem redundant, but it probably isn't.
 	*/
-	if((iFlags & FL_ONGROUND) == 0)
+	if((iFlags & (FL_ONGROUND | FL_INWATER)) == 0)
 	{
 		// WARNING: UGLY CODE.
-		if((buttons & (IN_MOVELEFT | IN_MOVERIGHT)) != (IN_MOVELEFT | IN_MOVERIGHT) ||
+		if((buttons & (IN_MOVELEFT | IN_MOVERIGHT)) != (IN_MOVELEFT | IN_MOVERIGHT) &&
 			(buttons & (IN_FORWARD | IN_BACK)) != (IN_FORWARD | IN_BACK))
 		{
 			if( // A/D
@@ -365,7 +365,7 @@ Action SetupMove(int client, int &buttons, float angles[3], float vel[3])
 
 			int iTick = gI_KeyTransitionTick[client] - gI_AngleTransitionTick[client];
 			
-			if(iTick > -26 && iTick < 26)
+			if(-25 <= iTick <= 25)
 			{
 				gA_StrafeHistory[client].Push(iTick);
 				gI_CurrentStrafe[client]++;

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -582,7 +582,7 @@ void AnalyzeBASHStats(int client)
 		char[] sStrafeStats = new char[256];
 		FormatStrafeStats(client, sStrafeStats, 256);
 
-		Oryx_PrintToAdminsConsole(sStrafeStats);
+		Oryx_PrintToAdminsConsole("%s", sStrafeStats);
 		LogToFileEx(gS_LogPath, "%L - (%d tick difference, %d zeroes) %s", client, iTickDifference, iZeroes, sStrafeStats);
 
 		return;
@@ -612,7 +612,7 @@ void AnalyzeBASHStats(int client)
 		char[] sStrafeStats = new char[256];
 		FormatStrafeStats(client, sStrafeStats, 256);
 
-		Oryx_PrintToAdminsConsole(sStrafeStats);
+		Oryx_PrintToAdminsConsole("%s", sStrafeStats);
 		LogToFileEx(gS_LogPath, "%L - (%d tick difference, %d zeroes) %s", client, iTickDifference, iZeroes, sStrafeStats);
 	}
 }

--- a/addons/sourcemod/scripting/oryx-strafe.sp
+++ b/addons/sourcemod/scripting/oryx-strafe.sp
@@ -542,7 +542,7 @@ void AnalyzeBASHStats(int client)
 		FormatStrafeStats(client, sStrafeStats, 256);
 
 		Oryx_PrintToAdminsConsole(sStrafeStats);
-		LogToFileEx(gS_LogPath, "%L - %s", client, sStrafeStats);
+		LogToFileEx(gS_LogPath, "%L - (%d tick difference, %d zeroes) %s", client, iTickDifference, iZeroes, sStrafeStats);
 
 		return;
 	}
@@ -572,6 +572,6 @@ void AnalyzeBASHStats(int client)
 		FormatStrafeStats(client, sStrafeStats, 256);
 
 		Oryx_PrintToAdminsConsole(sStrafeStats);
-		LogToFileEx(gS_LogPath, "%L - %s", client, sStrafeStats);
+		LogToFileEx(gS_LogPath, "%L - (%d tick difference, %d zeroes) %s", client, iTickDifference, iZeroes, sStrafeStats);
 	}
 }

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -244,14 +244,16 @@ public int Native_WithinThreshold(Handle plugin, int numParams)
 
 public int Native_PrintToAdmins(Handle plugin, int numParams)
 {
-	char[] sMessage = new char[256];
-	GetNativeString(1, sMessage, 256);
+	static int iWritten = 0; // Useless?
+
+	char[] sBuffer = new char[300];
+	FormatNativeString(0, 1, 2, 300, iWritten, sBuffer);
 
 	for(int i = 1; i <= MaxClients; i++)
 	{
 		if(CheckCommandAccess(i, "oryx_admin", ADMFLAG_GENERIC))
 		{
-			PrintToChat(i, "%s\x04[ORYX]\x01 %s", (gEV_Type == Engine_CSGO)? " ":"", sMessage);
+			PrintToChat(i, "%s\x04[ORYX]\x01 %s", (gEV_Type == Engine_CSGO)? " ":"", sBuffer);
 
 			if(!gB_NoSound)
 			{
@@ -273,14 +275,16 @@ public int Native_PrintToAdmins(Handle plugin, int numParams)
 
 public int Native_PrintToAdminsConsole(Handle plugin, int numParams)
 {
-	char[] sMessage = new char[256];
-	GetNativeString(1, sMessage, 256);
+	static int iWritten = 0; // Useless?
+
+	char[] sBuffer = new char[300];
+	FormatNativeString(0, 1, 2, 300, iWritten, sBuffer);
 
 	for(int i = 1; i <= MaxClients; i++)
 	{
 		if(CheckCommandAccess(i, "oryx_admin", ADMFLAG_GENERIC))
 		{
-			PrintToConsole(i, "[ORYX] %s", sMessage);
+			PrintToConsole(i, "[ORYX] %s", sBuffer);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -267,10 +267,10 @@ public int Native_PrintToAdmins(Handle plugin, int numParams)
 					ClientCommand(i, "play */%s", gS_BeepSound);
 				}
 			}
-
-			gB_NoSound = false;
 		}
 	}
+
+	gB_NoSound = false;
 }
 
 public int Native_PrintToAdminsConsole(Handle plugin, int numParams)

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -49,6 +49,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("Oryx_WithinThreshold", Native_WithinThreshold);
 	CreateNative("Oryx_PrintToAdmins", Native_PrintToAdmins);
 	CreateNative("Oryx_PrintToAdminsConsole", Native_PrintToAdminsConsole);
+	CreateNative("Oryx_LogMessage", Native_LogMessage);
 
 	// registers library, check "bool LibraryExists(const char[] name)" in order to use with other plugins
 	RegPluginLibrary("oryx");
@@ -282,4 +283,21 @@ public int Native_PrintToAdminsConsole(Handle plugin, int numParams)
 			PrintToConsole(i, "[ORYX] %s", sMessage);
 		}
 	}
+}
+
+public int Native_LogMessage(Handle plugin, int numParams)
+{
+	char[] sPlugin = new char[32];
+
+	if(!GetPluginInfo(plugin, PlInfo_Name, sPlugin, 32))
+	{
+		GetPluginFilename(plugin, sPlugin, 32);
+	}
+
+	static int iWritten = 0; // Useless?
+
+	char[] sBuffer = new char[300];
+	FormatNativeString(0, 1, 2, 300, iWritten, sBuffer);
+	
+	LogToFileEx(gS_LogPath, "%s", sBuffer);
 }

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -303,5 +303,5 @@ public int Native_LogMessage(Handle plugin, int numParams)
 	char[] sBuffer = new char[300];
 	FormatNativeString(0, 1, 2, 300, iWritten, sBuffer);
 	
-	LogToFileEx(gS_LogPath, "%s", sBuffer);
+	LogToFileEx(gS_LogPath, "[%s] %s", sPlugin, sBuffer);
 }

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -37,7 +37,7 @@ enum
 }
 
 int gI_Timer = Timer_None;
-char gS_SpecialString[32];
+char gS_SpecialString[128];
 
 ConVar gCV_AllowBypass = null;
 
@@ -226,7 +226,7 @@ public int Native_CanBypass(Handle plugin, int numParams)
 	{
 		case Timer_Shavit:
 		{
-			Shavit_GetStyleStrings(Shavit_GetBhopStyle(client), sSpecialString, gS_SpecialString, 32);
+			Shavit_GetStyleStrings(Shavit_GetBhopStyle(client), sSpecialString, gS_SpecialString, 128);
 
 			if(StrContains(gS_SpecialString, "oryx_bypass", false) != -1)
 			{

--- a/addons/sourcemod/scripting/oryx.sp
+++ b/addons/sourcemod/scripting/oryx.sp
@@ -226,7 +226,7 @@ public int Native_OryxTrigger(Handle plugin, int numParams)
 
 	char[] sBuffer = new char[128];
 	Format(sBuffer, 128, "\x03%N\x01 - \x05%s\x01 Cheat: %s | Level: %s", client, sAuth, sCheatDescription, sLevel);
-	Oryx_PrintToAdmins(sBuffer);
+	Oryx_PrintToAdmins("%s", sBuffer);
 	
 	LogToFileEx(gS_LogPath, "%L - Cheat: %s | Level: %s", client, sCheatDescription, sLevel);
 


### PR DESCRIPTION
* Fixed false 0 stats in oryx-strafe. It's still not perfect, but getting close to it!
* Fixed strafe stat logging not showing player info.
* Added tick difference and 0 counter to strafe logging.
* Added logging native and improved existing natives with formatting.
* Added invalid buttons/wishspeeds detection.
* Added [bTimes v1.8.3](https://github.com/Nolan-O/bTimes) and bTimes2 support. I don't have access to bTimes2 so I cannot verify if my addition works though.
* Fixed +left/right bypass false detections on surf maps. It still occurs, but not as often. (thanks slidy!)
* Adjusted detection levels.
* Fixed low detection not beeping for only one admin.
* Adjusted the plugin so that it can run on any server regardless of if it uses no timer, bhoptimer or bTimes.

Note:

* Scroll module support does not exist for bTimes servers with both scroll and auto styles. If you own bTimes2 and know how to determine whether a player is using autobhop or not via the API, let me know and I'll add support.